### PR TITLE
wcコマンドの提出

### DIFF
--- a/06.wc/wc.rb
+++ b/06.wc/wc.rb
@@ -1,3 +1,4 @@
+#!/usr/bin/env ruby
 # frozen_string_literal: true
 
 require 'optparse'

--- a/06.wc/wc.rb
+++ b/06.wc/wc.rb
@@ -44,3 +44,9 @@ def has_argument
     puts "#{total_lines} #{total_words} #{total_bytes} total"
   end
 end
+
+if @file == []
+  has_argument
+else
+  non_argument
+end

--- a/06.wc/wc.rb
+++ b/06.wc/wc.rb
@@ -34,13 +34,11 @@ def argument?
 end
 
 def result
-  if @option['l'] == true
-    print @lines.to_s.rjust(8)
-  else
-    print @lines.to_s.rjust(8)
-    print @words.to_s.rjust(8)
-    print @bytes.to_s.rjust(8)
-  end
+  print @lines.to_s.rjust(8)
+  return unless @option['l'] == false
+
+  print @words.to_s.rjust(8)
+  print @bytes.to_s.rjust(8)
 end
 
 def calc_lines_words_bytes

--- a/06.wc/wc.rb
+++ b/06.wc/wc.rb
@@ -13,32 +13,43 @@ else
   end
 end
 
-def calc_lines_words_bytes
-  @lines = @contents.count("\n")
-  @words = @contents.split(/\s+/).size
-  @bytes = @contents.bytesize
-end
-
-# 引数がなしの時
-if @files == [] && @option['l'] == false
-  calc_lines_words_bytes
-  puts "#{@lines} #{@words} #{@bytes}"
-elsif @files == [] && @option['l'] == true
-  @lines = @contents.count("\n")
-  printf "%7d\n", @lines
-end
-
-# 引数ありの時
-# 引数あり && オプションなし, 引数あり && オプションあり
-if @files != [] && @option["l"] == false
-  @files.each do |file|
-    @contents = File.read(file)
-    calc_lines_words_bytes
-    puts "#{@lines} #{@words} #{@bytes} #{file}"
+def result
+  print @lines
+  unless @option['l']
+    print @lines
+    print @words
+    print @bytes
   end
-  total_lines = total_words = total_bytes = 0
-  total_lines += @lines
-  total_words += @words
-  total_bytes += @bytes
-  puts "#{total_lines} #{total_words} #{total_bytes} total"
+end
+
+def calc_lines_words_bytes
+  @lines = calc_lines(str)
+  @words = calc_words(str)
+  @bytes = calc_bytes(str)
+end
+
+def calc_lines(str)
+  str.count("\n")
+end
+
+def calc_words(str)
+  str.split(/\s+/).size
+end
+
+def calc_bytes(str)
+  str.bytesize
+end
+
+def calc_total
+  @total_lines += @contents.count("\n")
+  @total_words += @contents.split(/\s+/).size
+  @total_bytes += @contents.bytesize
+end
+
+def display_total
+  print @total_lines
+  if @option['l'] == false
+    print @total_words
+    print @total_bytes
+  end
 end

--- a/06.wc/wc.rb
+++ b/06.wc/wc.rb
@@ -7,18 +7,25 @@ require 'optparse'
 if @files == []
   @contents = $stdin.read
 else
+  has_argument
+  end
+end
+
+def has_argument
   @files.each do |file|
     @contents = File.read(file)
     calc_lines_words_bytes
+    result
+    print "#{file}"
   end
 end
 
 def result
   print @lines
   unless @option['l']
-    print @lines
-    print @words
-    print @bytes
+    print @lines.to_s.rjust(8)
+    print @words.to_s.rjust(8)
+    print @bytes.to_s.rjust(8)
   end
 end
 
@@ -41,15 +48,16 @@ def calc_bytes(str)
 end
 
 def calc_total
+  @total_lines = @total_words = @total_bytes = 0
   @total_lines += @contents.count("\n")
   @total_words += @contents.split(/\s+/).size
   @total_bytes += @contents.bytesize
 end
 
 def display_total
-  print @total_lines
+  print @total_lines.to_s.rjust(8)
   if @option['l'] == false
-    print @total_words
-    print @total_bytes
+    print @total_words.to_s.rjust(8)
+    print @total_bytes.to_s.rjust(8)
   end
 end

--- a/06.wc/wc.rb
+++ b/06.wc/wc.rb
@@ -4,11 +4,20 @@ require 'optparse'
 
 @option = ARGV.getopts('l')
 @files = ARGV
-if @files == []
-  @contents = $stdin.read
-else
-  has_argument
+
+def main
+  if @files == []
+    @contents = $stdin.read
+    non_argument
+  else
+    has_argument
   end
+end
+
+def non_argument
+  calc_lines_words_bytes
+  result
+  puts
 end
 
 def has_argument
@@ -17,12 +26,16 @@ def has_argument
     calc_lines_words_bytes
     result
     print "#{file}"
+    puts
+    calc_total
   end
+  display_total if @files[1]
 end
 
 def result
-  print @lines
-  unless @option['l']
+  if @option['l'] == true
+    print @lines.to_s.rjust(8)
+  else
     print @lines.to_s.rjust(8)
     print @words.to_s.rjust(8)
     print @bytes.to_s.rjust(8)
@@ -30,21 +43,9 @@ def result
 end
 
 def calc_lines_words_bytes
-  @lines = calc_lines(str)
-  @words = calc_words(str)
-  @bytes = calc_bytes(str)
-end
-
-def calc_lines(str)
-  str.count("\n")
-end
-
-def calc_words(str)
-  str.split(/\s+/).size
-end
-
-def calc_bytes(str)
-  str.bytesize
+  @lines = @contents.count("\n")
+  @words = @contents.split(/\s+/).size
+  @bytes = @contents.bytesize
 end
 
 def calc_total
@@ -55,9 +56,15 @@ def calc_total
 end
 
 def display_total
-  print @total_lines.to_s.rjust(8)
   if @option['l'] == false
+    print @total_lines.to_s.rjust(8)
     print @total_words.to_s.rjust(8)
     print @total_bytes.to_s.rjust(8)
+  else
+    print @total_lines.to_s.rjust(8)
   end
+  print "total"
+  puts
 end
+
+main

--- a/06.wc/wc.rb
+++ b/06.wc/wc.rb
@@ -30,7 +30,7 @@ def argument?
     puts
     calc_total
   end
-  display_total if @files[1]
+  display_total if @files != []
 end
 
 def result

--- a/06.wc/wc.rb
+++ b/06.wc/wc.rb
@@ -25,7 +25,7 @@ if @files == [] && @option['l'] == false
   puts "#{@lines} #{@words} #{@bytes}"
 elsif @files == [] && @option['l'] == true
   @lines = @contents.count("\n")
-  puts "#{@lines}"
+  printf "%7d\n", @lines
 end
 
 

--- a/06.wc/wc.rb
+++ b/06.wc/wc.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require 'optparse'
+options = ARGV.getopts('l')
+
+# オプションなしを実装していく
+text = $stdin.read
+
+p text.count("\n")
+p word = text.split(/\s+/).size
+p text.bytesize

--- a/06.wc/wc.rb
+++ b/06.wc/wc.rb
@@ -52,9 +52,9 @@ def calc_lines_words_bytes
 end
 
 def calc_total
-  @total_lines += @contents.count("\n")
-  @total_words += @contents.split(/\s+/).size
-  @total_bytes += @contents.bytesize
+  @total_lines += @lines
+  @total_words += @words
+  @total_bytes += @bytes
 end
 
 def display_total

--- a/06.wc/wc.rb
+++ b/06.wc/wc.rb
@@ -5,10 +5,6 @@ require 'optparse'
 option = ARGV.getopts('l')
 @files = ARGV
 
-total_lines = 0
-total_words = 0
-total_bytes = 0
-
 # 引数がなかった時
 # 標準入力して改行数、単語数、バイト数、ファイル名を出力
 def non_argument
@@ -30,6 +26,10 @@ end
 
 # 引数ありの処理
 def has_argument
+  total_lines = 0
+  total_words = 0
+  total_bytes = 0
+
   @files.each do |file|
     content = File.read(file)
     lines = content.count("\n")
@@ -45,8 +45,8 @@ def has_argument
   end
 end
 
-if @file == []
-  has_argument
-else
+if @files == []
   non_argument
+else
+  has_argument
 end

--- a/06.wc/wc.rb
+++ b/06.wc/wc.rb
@@ -5,19 +5,9 @@ require 'optparse'
 option = ARGV.getopts('l')
 @files = ARGV
 
-# text = $stdin.read
-# p lines = text.count("\n")
-# p word = text.split(/\s+/).size
-# p bytes = text.bytesize
- 
-# -lオプションの実装
-# 改行数だけを出力
-def l_option
-  @files.each do |file|
-    content = File.read(file)
-    puts content.count("\n")
-  end
-end
+total_lines = 0
+total_words = 0
+total_bytes = 0
 
 # 引数がなかった時
 # 標準入力して改行数、単語数、バイト数、ファイル名を出力
@@ -29,11 +19,16 @@ def non_argument
   puts "#{lines} #{words} #{bytes}"
 end
 
-# 引数ありの処理
-total_lines = 0
-total_words = 0
-total_bytes = 0
+# -lオプションの実装
+# 改行数だけを出力
+def l_option
+  @files.each do |file|
+    content = File.read(file)
+    puts content.count("\n")
+  end
+end
 
+# 引数ありの処理
 def has_argument
   @files.each do |file|
     content = File.read(file)
@@ -48,13 +43,4 @@ def has_argument
     puts "#{lines} #{words} #{bytes} #{file}"
     puts "#{total_lines} #{total_words} #{total_bytes} total"
   end
-end
-
-if option['l'] == true
-  l_option
-else
-  non_argument
-end
-
-if 
 end

--- a/06.wc/wc.rb
+++ b/06.wc/wc.rb
@@ -9,68 +9,36 @@ if @files == []
 else
   @files.each do |file|
     @contents = File.read(file)
-    @lines = @contents.count("\n")
-    @words = @contents.split(/\s+/).size
-    @bytes = @contents.bytesize
+    calc_lines_words_bytes
   end
 end
 
-# 引数がなしの時
-# 標準入力の改行数、バイト数、単語数を表示
-# lオプションのときだけ改行数を表示する
-if @files == [] && @option['l'] == false
+def calc_lines_words_bytes
   @lines = @contents.count("\n")
   @words = @contents.split(/\s+/).size
   @bytes = @contents.bytesize
+end
+
+# 引数がなしの時
+if @files == [] && @option['l'] == false
+  calc_lines_words_bytes
   puts "#{@lines} #{@words} #{@bytes}"
 elsif @files == [] && @option['l'] == true
   @lines = @contents.count("\n")
   printf "%7d\n", @lines
 end
 
-
-# def calc_lines_words_bytes
-#   @lines = @contents.count("\n")
-#   @words = @contents.split(/\s+/).size
-#   @bytes = @contents.bytesize
-# end
-
-# def result
-#   if @option['l'] == true
-#     puts @lines
-#   else
-#     print @lines
-#     print @words
-#     print @bytes
-#   end
-# end
-# # 引数がなかった時
-# # 標準入力して改行数、単語数、バイト数、ファイル名を出力
-# def non_argument
-
-#   puts "#{lines} #{words} #{bytes}"
-# end
-
-# # 引数ありの処理
-# def has_argument
-#   @files.each do |file|
-#     @contents = File.read(file)
-#     puts "#{@lines} #{@words} #{@bytes} #{@file}"
-#   end
-#   display_total
-# end
-
-# # トータルを計算する処理を切り出す
-# def calc_total
-#   @total_lines = @total_words = @total_bytes = 0
-#   @total_lines += @lines
-#   @total_words += @words
-#   @total_bytes += @bytes
-# end
-
-# # トータルを表示する処理
-# def display_total
-#   print @total_lines
-#   print @total_words
-#   print @total_bytes
-# end
+# 引数ありの時
+# 引数あり && オプションなし, 引数あり && オプションあり
+if @files != [] && @option["l"] == false
+  @files.each do |file|
+    @contents = File.read(file)
+    calc_lines_words_bytes
+    puts "#{@lines} #{@words} #{@bytes} #{file}"
+  end
+  total_lines = total_words = total_bytes = 0
+  total_lines += @lines
+  total_words += @words
+  total_bytes += @bytes
+  puts "#{total_lines} #{total_words} #{total_bytes} total"
+end

--- a/06.wc/wc.rb
+++ b/06.wc/wc.rb
@@ -1,24 +1,29 @@
 # frozen_string_literal: true
 
 require 'optparse'
+
 option = ARGV.getopts('l')
+@files = ARGV
 
-# オプションなしを実装していく
 text = $stdin.read
-
 p lines = text.count("\n")
 p word = text.split(/\s+/).size
 p bytes = text.bytesize
-
+ 
 # -lオプションの実装
-p lines = text.count("\n") if option['l']
+# 改行数だけを出力
+def l_option
+  @files.each do |file|
+    content = File.read(file)
+    puts content.count("\n")
+  end
+end
 
 # 引数ありの処理
 total_lines = 0
 total_words = 0
 total_bytes = 0
 
-files = ARGV
 files.each do |file|
   content = File.read(file)
   lines = content.count("\n")

--- a/06.wc/wc.rb
+++ b/06.wc/wc.rb
@@ -34,7 +34,6 @@ def with_argument
   display_total if @files != []
 end
 
-# @option == true の形で書いてみる
 def show_result(lines, words, bytes)
 
   print lines.to_s.rjust(8)

--- a/06.wc/wc.rb
+++ b/06.wc/wc.rb
@@ -54,15 +54,13 @@ def calc_total
 end
 
 def display_total
-  if @option['l'] == false
-    print @total_lines.to_s.rjust(8)
-    print @total_words.to_s.rjust(8)
-    print @total_bytes.to_s.rjust(8)
-  else
-    print @total_lines.to_s.rjust(8)
-  end
+  print @total_lines.to_s.rjust(8)
   print ' total'
   puts
+  return unless @option['l'] == false
+
+  print @total_words.to_s.rjust(8)
+  print @total_bytes.to_s.rjust(8)
 end
 
 main

--- a/06.wc/wc.rb
+++ b/06.wc/wc.rb
@@ -55,12 +55,12 @@ end
 
 def display_total
   print @total_lines.to_s.rjust(8)
+  if @option['l'] == false
+    print @total_words.to_s.rjust(8)
+    print @total_bytes.to_s.rjust(8)
+  end
   print ' total'
   puts
-  return unless @option['l'] == false
-
-  print @total_words.to_s.rjust(8)
-  print @total_bytes.to_s.rjust(8)
 end
 
 main

--- a/06.wc/wc.rb
+++ b/06.wc/wc.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
 require 'optparse'
-options = ARGV.getopts('l')
+option = ARGV.getopts('l')
+file = ARGV
 
 # オプションなしを実装していく
 text = $stdin.read
@@ -9,3 +10,10 @@ text = $stdin.read
 p text.count("\n")
 p word = text.split(/\s+/).size
 p text.bytesize
+
+p file
+
+# 引数ありのとき
+# 引数に受けたファイルの改行数・単語数・バイト数とtotalをputsする
+
+

--- a/06.wc/wc.rb
+++ b/06.wc/wc.rb
@@ -5,9 +5,6 @@ require 'optparse'
 
 @option = ARGV.getopts('l')
 
-if @option.empty?
-  @option['l'] == true
-end
 @files = ARGV
 
 def main
@@ -22,7 +19,7 @@ end
 
 def non_argument
   lines, words, bytes = calc_lines_words_bytes
-  result(lines, words, bytes)
+  show_result(lines, words, bytes)
   puts
 end
 
@@ -30,15 +27,16 @@ def with_argument
   @files.each do |file|
     @contents = File.read(file)
     lines, words, bytes = calc_lines_words_bytes
-    result(lines, words, bytes)
+    show_result(lines, words, bytes)
     puts " #{file}"
     calc_total(lines, words, bytes)
   end
   display_total if @files != []
 end
 
+# @option == true の形で書いてみる
 def show_result(lines, words, bytes)
-  
+
   print lines.to_s.rjust(8)
   return unless @option['l'] == false
 

--- a/06.wc/wc.rb
+++ b/06.wc/wc.rb
@@ -8,10 +8,10 @@ require 'optparse'
 # 引数がなかった時
 # 標準入力して改行数、単語数、バイト数、ファイル名を出力
 def non_argument
-  text = $stdin.read
-  lines = text.count("\n")
-  words = text.split(/\s+/).size
-  bytes = text.bytesize
+  @contents = $stdin.read
+  lines = @contents.count("\n")
+  words = @contents.split(/\s+/).size
+  bytes = @contents.bytesize
   puts "#{lines} #{words} #{bytes}"
 end
 
@@ -29,9 +29,7 @@ end
 
 # トータルを計算する処理を切り出す
 def calc_total
-  @total_lines = 0
-  @total_words = 0
-  @total_bytes = 0
+  @total_lines = @total_words = @total_bytes = 0
   @total_lines += @lines
   @total_words += @words
   @total_bytes += @bytes
@@ -39,11 +37,9 @@ end
 
 # トータルを表示する処理
 def display_total
-    print @total_lines
-  if @option["l"] == false
-    print @total_words
-    print @total_bytes
-  end
+  print @total_lines
+  print @total_words
+  print @total_bytes
 end
 
 if @files == []

--- a/06.wc/wc.rb
+++ b/06.wc/wc.rb
@@ -5,6 +5,10 @@ require 'optparse'
 option = ARGV.getopts('l')
 @files = ARGV
 
+total_lines = 0
+total_words = 0
+total_bytes = 0
+
 # 引数がなかった時
 # 標準入力して改行数、単語数、バイト数、ファイル名を出力
 def non_argument
@@ -15,38 +19,30 @@ def non_argument
   puts "#{lines} #{words} #{bytes}"
 end
 
-# -lオプションの実装
-# 改行数だけを出力
-def l_option
-  @files.each do |file|
-    content = File.read(file)
-    puts content.count("\n")
-  end
-end
-
 # 引数ありの処理
 def has_argument
-  total_lines = 0
-  total_words = 0
-  total_bytes = 0
-
   @files.each do |file|
     content = File.read(file)
     lines = content.count("\n")
     words = content.split(/\s+/).size
     bytes = content.bytesize
-  
-    total_lines += content.count("\n")
-    total_words += content.split(/\s+/).size
-    total_bytes += content.bytesize
-  
     puts "#{lines} #{words} #{bytes} #{file}"
-    puts "#{total_lines} #{total_words} #{total_bytes} total"
   end
+  puts_total if 
 end
 
-if @files == []
-  non_argument
-else
-  has_argument
+# トータルを計算する処理を切り出す
+def calc_total
+  total_lines += content.count("\n")
+  total_words += content.split(/\s+/).size
+  total_bytes += content.bytesize
+end
+
+# トータルを表示する処理
+def puts_total
+    puts total_lines
+  if option["l"] == false
+    puts total_words
+    puts total_bytes
+  end
 end

--- a/06.wc/wc.rb
+++ b/06.wc/wc.rb
@@ -3,14 +3,17 @@
 require 'optparse'
 option = ARGV.getopts('l')
 
-
 # オプションなしを実装していく
 text = $stdin.read
 
-p text.count("\n")
+p lines = text.count("\n")
 p word = text.split(/\s+/).size
-p text.bytesize
+p bytes = text.bytesize
 
+# -lオプションの実装
+if option["l"]
+  p lines = text.count("\n")
+end
 # 引数ありのとき
 # 引数に受けたファイルの改行数・単語数・バイト数とfile名をputsする
 

--- a/06.wc/wc.rb
+++ b/06.wc/wc.rb
@@ -5,10 +5,10 @@ require 'optparse'
 option = ARGV.getopts('l')
 @files = ARGV
 
-text = $stdin.read
-p lines = text.count("\n")
-p word = text.split(/\s+/).size
-p bytes = text.bytesize
+# text = $stdin.read
+# p lines = text.count("\n")
+# p word = text.split(/\s+/).size
+# p bytes = text.bytesize
  
 # -lオプションの実装
 # 改行数だけを出力
@@ -19,21 +19,42 @@ def l_option
   end
 end
 
+# 引数がなかった時
+# 標準入力して改行数、単語数、バイト数、ファイル名を出力
+def non_argument
+  text = $stdin.read
+  lines = text.count("\n")
+  words = text.split(/\s+/).size
+  bytes = text.bytesize
+  puts "#{lines} #{words} #{bytes}"
+end
+
 # 引数ありの処理
 total_lines = 0
 total_words = 0
 total_bytes = 0
 
-files.each do |file|
-  content = File.read(file)
-  lines = content.count("\n")
-  words = content.split(/\s+/).size
-  bytes = content.bytesize
+def has_argument
+  @files.each do |file|
+    content = File.read(file)
+    lines = content.count("\n")
+    words = content.split(/\s+/).size
+    bytes = content.bytesize
+  
+    total_lines += content.count("\n")
+    total_words += content.split(/\s+/).size
+    total_bytes += content.bytesize
+  
+    puts "#{lines} #{words} #{bytes} #{file}"
+    puts "#{total_lines} #{total_words} #{total_bytes} total"
+  end
+end
 
-  total_lines += content.count("\n")
-  total_words += content.split(/\s+/).size
-  total_bytes += content.bytesize
+if option['l'] == true
+  l_option
+else
+  non_argument
+end
 
-  puts "#{lines} #{words} #{bytes} #{file}"
-  puts "#{total_lines} #{total_words} #{total_bytes} total"
+if 
 end

--- a/06.wc/wc.rb
+++ b/06.wc/wc.rb
@@ -63,7 +63,7 @@ def display_total
   else
     print @total_lines.to_s.rjust(8)
   end
-  print " total"
+  print ' total'
   puts
 end
 

--- a/06.wc/wc.rb
+++ b/06.wc/wc.rb
@@ -9,24 +9,24 @@ require 'optparse'
 
 def main
   if @files.empty?
-    @contents = $stdin.read
-    non_argument
+    contents = $stdin.read
+    non_argument(contents)
   else
     @total_lines = @total_words = @total_bytes = 0
-    with_argument
+    with_argument(contents)
   end
 end
 
-def non_argument
-  lines, words, bytes = calc_lines_words_bytes
+def non_argument(contents)
+  lines, words, bytes = calc_lines_words_bytes(contents)
   show_result(lines, words, bytes)
   puts
 end
 
-def with_argument
+def with_argument(contents)
   @files.each do |file|
-    @contents = File.read(file)
-    lines, words, bytes = calc_lines_words_bytes
+    contents = File.read(file)
+    lines, words, bytes = calc_lines_words_bytes(contents)
     show_result(lines, words, bytes)
     puts " #{file}"
     calc_total(lines, words, bytes)
@@ -43,10 +43,10 @@ def show_result(lines, words, bytes)
   print bytes.to_s.rjust(8)
 end
 
-def calc_lines_words_bytes
-  lines = @contents.count("\n")
-  words = @contents.split(/\s+/).size
-  bytes = @contents.bytesize
+def calc_lines_words_bytes(contents)
+  lines = contents.count("\n")
+  words = contents.split(/\s+/).size
+  bytes = contents.bytesize
   [lines, words, bytes]
 end
 

--- a/06.wc/wc.rb
+++ b/06.wc/wc.rb
@@ -12,7 +12,7 @@ def main
     non_argument
   else
     @total_lines = @total_words = @total_bytes = 0
-    argument?
+    with_argument
   end
 end
 
@@ -22,7 +22,7 @@ def non_argument
   puts
 end
 
-def argument?
+def with_argument
   @files.each do |file|
     @contents = File.read(file)
     calc_lines_words_bytes

--- a/06.wc/wc.rb
+++ b/06.wc/wc.rb
@@ -25,7 +25,7 @@ def has_argument
     @contents = File.read(file)
     calc_lines_words_bytes
     result
-    print "#{file}"
+    print " #{file}"
     puts
     calc_total
   end
@@ -63,7 +63,7 @@ def display_total
   else
     print @total_lines.to_s.rjust(8)
   end
-  print "total"
+  print " total"
   puts
 end
 

--- a/06.wc/wc.rb
+++ b/06.wc/wc.rb
@@ -13,11 +13,21 @@ p text.bytesize
 
 # 引数ありのとき
 # 引数に受けたファイルの改行数・単語数・バイト数とfile名をputsする
+total_lines = 0
+total_words = 0
+total_bytes = 0
+
 files = ARGV
 files.each do |file|
   content = File.read(file)
   lines = content.count("\n")
   words = content.split(/\s+/).size
   bytes = content.bytesize
+
+  total_lines += content.count("\n")
+  total_words += content.split(/\s+/).size
+  total_bytes += content.bytesize
+
   puts "#{lines} #{words} #{bytes} #{file}"
+  puts "#{total_lines} #{total_words} #{total_bytes} total"
 end

--- a/06.wc/wc.rb
+++ b/06.wc/wc.rb
@@ -2,7 +2,7 @@
 
 require 'optparse'
 option = ARGV.getopts('l')
-file = ARGV
+
 
 # オプションなしを実装していく
 text = $stdin.read
@@ -11,9 +11,13 @@ p text.count("\n")
 p word = text.split(/\s+/).size
 p text.bytesize
 
-p file
-
 # 引数ありのとき
-# 引数に受けたファイルの改行数・単語数・バイト数とtotalをputsする
-
-
+# 引数に受けたファイルの改行数・単語数・バイト数とfile名をputsする
+files = ARGV
+files.each do |file|
+  content = File.read(file)
+  lines = content.count("\n")
+  words = content.split(/\s+/).size
+  bytes = content.bytesize
+  puts "#{lines} #{words} #{bytes} #{file}"
+end

--- a/06.wc/wc.rb
+++ b/06.wc/wc.rb
@@ -13,21 +13,24 @@ p text.bytesize
 
 # 引数ありのとき
 # 引数に受けたファイルの改行数・単語数・バイト数とfile名をputsする
-total_lines = 0
-total_words = 0
-total_bytes = 0
 
-files = ARGV
-files.each do |file|
-  content = File.read(file)
-  lines = content.count("\n")
-  words = content.split(/\s+/).size
-  bytes = content.bytesize
+def has_argv
+  total_lines = 0
+  total_words = 0
+  total_bytes = 0
 
-  total_lines += content.count("\n")
-  total_words += content.split(/\s+/).size
-  total_bytes += content.bytesize
+  files = ARGV
+  files.each do |file|
+    content = File.read(file)
+    lines = content.count("\n")
+    words = content.split(/\s+/).size
+    bytes = content.bytesize
 
-  puts "#{lines} #{words} #{bytes} #{file}"
-  puts "#{total_lines} #{total_words} #{total_bytes} total"
+    total_lines += content.count("\n")
+    total_words += content.split(/\s+/).size
+    total_bytes += content.bytesize
+
+    puts "#{lines} #{words} #{bytes} #{file}"
+    puts "#{total_lines} #{total_words} #{total_bytes} total"
+  end
 end

--- a/06.wc/wc.rb
+++ b/06.wc/wc.rb
@@ -7,7 +7,7 @@ require 'optparse'
 @files = ARGV
 
 def main
-  if @files == []
+  if @files.empty?
     @contents = $stdin.read
     non_argument
   else
@@ -27,8 +27,7 @@ def argument?
     @contents = File.read(file)
     calc_lines_words_bytes
     result
-    print " #{file}"
-    puts
+    puts " #{file}"
     calc_total
   end
   display_total if @files != []

--- a/06.wc/wc.rb
+++ b/06.wc/wc.rb
@@ -4,48 +4,73 @@ require 'optparse'
 
 @option = ARGV.getopts('l')
 @files = ARGV
-
-# 引数がなかった時
-# 標準入力して改行数、単語数、バイト数、ファイル名を出力
-def non_argument
+if @files == []
   @contents = $stdin.read
-  lines = @contents.count("\n")
-  words = @contents.split(/\s+/).size
-  bytes = @contents.bytesize
-  puts "#{lines} #{words} #{bytes}"
-end
-
-# 引数ありの処理
-def has_argument
+else
   @files.each do |file|
     @contents = File.read(file)
     @lines = @contents.count("\n")
     @words = @contents.split(/\s+/).size
     @bytes = @contents.bytesize
-    puts "#{@lines} #{@words} #{@bytes} #{@file}"
   end
-  display_total
 end
 
-# トータルを計算する処理を切り出す
-def calc_total
-  @total_lines = @total_words = @total_bytes = 0
-  @total_lines += @lines
-  @total_words += @words
-  @total_bytes += @bytes
+# 引数がなしの時
+# 標準入力の改行数、バイト数、単語数を表示
+# lオプションのときだけ改行数を表示する
+if @files == [] && @option['l'] == false
+  @lines = @contents.count("\n")
+  @words = @contents.split(/\s+/).size
+  @bytes = @contents.bytesize
+  puts "#{@lines} #{@words} #{@bytes}"
+elsif @files == [] && @option['l'] == true
+  @lines = @contents.count("\n")
+  puts "#{@lines}"
 end
 
-# トータルを表示する処理
-def display_total
-  print @total_lines
-  print @total_words
-  print @total_bytes
-end
 
-if @files == []
-  non_argument
-else
-  has_argument
-  calc_total
-  display_total
-end
+# def calc_lines_words_bytes
+#   @lines = @contents.count("\n")
+#   @words = @contents.split(/\s+/).size
+#   @bytes = @contents.bytesize
+# end
+
+# def result
+#   if @option['l'] == true
+#     puts @lines
+#   else
+#     print @lines
+#     print @words
+#     print @bytes
+#   end
+# end
+# # 引数がなかった時
+# # 標準入力して改行数、単語数、バイト数、ファイル名を出力
+# def non_argument
+
+#   puts "#{lines} #{words} #{bytes}"
+# end
+
+# # 引数ありの処理
+# def has_argument
+#   @files.each do |file|
+#     @contents = File.read(file)
+#     puts "#{@lines} #{@words} #{@bytes} #{@file}"
+#   end
+#   display_total
+# end
+
+# # トータルを計算する処理を切り出す
+# def calc_total
+#   @total_lines = @total_words = @total_bytes = 0
+#   @total_lines += @lines
+#   @total_words += @words
+#   @total_bytes += @bytes
+# end
+
+# # トータルを表示する処理
+# def display_total
+#   print @total_lines
+#   print @total_words
+#   print @total_bytes
+# end

--- a/06.wc/wc.rb
+++ b/06.wc/wc.rb
@@ -21,40 +21,42 @@ def main
 end
 
 def non_argument
-  calc_lines_words_bytes
-  result
+  lines, words, bytes = calc_lines_words_bytes
+  result(lines, words, bytes)
   puts
 end
 
 def with_argument
   @files.each do |file|
     @contents = File.read(file)
-    calc_lines_words_bytes
-    result
+    lines, words, bytes = calc_lines_words_bytes
+    result(lines, words, bytes)
     puts " #{file}"
-    calc_total
+    calc_total(lines, words, bytes)
   end
   display_total if @files != []
 end
 
-def result
-  print @lines.to_s.rjust(8)
+def show_result(lines, words, bytes)
+  
+  print lines.to_s.rjust(8)
   return unless @option['l'] == false
 
-  print @words.to_s.rjust(8)
-  print @bytes.to_s.rjust(8)
+  print words.to_s.rjust(8)
+  print bytes.to_s.rjust(8)
 end
 
 def calc_lines_words_bytes
-  @lines = @contents.count("\n")
-  @words = @contents.split(/\s+/).size
-  @bytes = @contents.bytesize
+  lines = @contents.count("\n")
+  words = @contents.split(/\s+/).size
+  bytes = @contents.bytesize
+  [lines, words, bytes]
 end
 
-def calc_total
-  @total_lines += @lines
-  @total_words += @words
-  @total_bytes += @bytes
+def calc_total(lines, words, bytes)
+  @total_lines += lines
+  @total_words += words
+  @total_bytes += bytes
 end
 
 def display_total

--- a/06.wc/wc.rb
+++ b/06.wc/wc.rb
@@ -4,6 +4,10 @@
 require 'optparse'
 
 @option = ARGV.getopts('l')
+
+if @option.empty?
+  @option['l'] == true
+end
 @files = ARGV
 
 def main

--- a/06.wc/wc.rb
+++ b/06.wc/wc.rb
@@ -2,12 +2,8 @@
 
 require 'optparse'
 
-option = ARGV.getopts('l')
+@option = ARGV.getopts('l')
 @files = ARGV
-
-total_lines = 0
-total_words = 0
-total_bytes = 0
 
 # 引数がなかった時
 # 標準入力して改行数、単語数、バイト数、ファイル名を出力
@@ -22,27 +18,38 @@ end
 # 引数ありの処理
 def has_argument
   @files.each do |file|
-    content = File.read(file)
-    lines = content.count("\n")
-    words = content.split(/\s+/).size
-    bytes = content.bytesize
-    puts "#{lines} #{words} #{bytes} #{file}"
+    @contents = File.read(file)
+    @lines = @contents.count("\n")
+    @words = @contents.split(/\s+/).size
+    @bytes = @contents.bytesize
+    puts "#{@lines} #{@words} #{@bytes} #{@file}"
   end
-  puts_total if 
+  display_total
 end
 
 # トータルを計算する処理を切り出す
 def calc_total
-  total_lines += content.count("\n")
-  total_words += content.split(/\s+/).size
-  total_bytes += content.bytesize
+  @total_lines = 0
+  @total_words = 0
+  @total_bytes = 0
+  @total_lines += @lines
+  @total_words += @words
+  @total_bytes += @bytes
 end
 
 # トータルを表示する処理
-def puts_total
-    puts total_lines
-  if option["l"] == false
-    puts total_words
-    puts total_bytes
+def display_total
+    print @total_lines
+  if @option["l"] == false
+    print @total_words
+    print @total_bytes
   end
+end
+
+if @files == []
+  non_argument
+else
+  has_argument
+  calc_total
+  display_total
 end

--- a/06.wc/wc.rb
+++ b/06.wc/wc.rb
@@ -11,7 +11,7 @@ def main
     non_argument
   else
     @total_lines = @total_words = @total_bytes = 0
-    has_argument
+    argument?
   end
 end
 
@@ -21,7 +21,7 @@ def non_argument
   puts
 end
 
-def has_argument
+def argument?
   @files.each do |file|
     @contents = File.read(file)
     calc_lines_words_bytes

--- a/06.wc/wc.rb
+++ b/06.wc/wc.rb
@@ -10,6 +10,7 @@ def main
     @contents = $stdin.read
     non_argument
   else
+    @total_lines = @total_words = @total_bytes = 0
     has_argument
   end
 end
@@ -49,7 +50,6 @@ def calc_lines_words_bytes
 end
 
 def calc_total
-  @total_lines = @total_words = @total_bytes = 0
   @total_lines += @contents.count("\n")
   @total_words += @contents.split(/\s+/).size
   @total_bytes += @contents.bytesize

--- a/06.wc/wc.rb
+++ b/06.wc/wc.rb
@@ -11,29 +11,24 @@ p word = text.split(/\s+/).size
 p bytes = text.bytesize
 
 # -lオプションの実装
-if option["l"]
-  p lines = text.count("\n")
-end
-# 引数ありのとき
-# 引数に受けたファイルの改行数・単語数・バイト数とfile名をputsする
+p lines = text.count("\n") if option['l']
 
-def has_argv
-  total_lines = 0
-  total_words = 0
-  total_bytes = 0
+# 引数ありの処理
+total_lines = 0
+total_words = 0
+total_bytes = 0
 
-  files = ARGV
-  files.each do |file|
-    content = File.read(file)
-    lines = content.count("\n")
-    words = content.split(/\s+/).size
-    bytes = content.bytesize
+files = ARGV
+files.each do |file|
+  content = File.read(file)
+  lines = content.count("\n")
+  words = content.split(/\s+/).size
+  bytes = content.bytesize
 
-    total_lines += content.count("\n")
-    total_words += content.split(/\s+/).size
-    total_bytes += content.bytesize
+  total_lines += content.count("\n")
+  total_words += content.split(/\s+/).size
+  total_bytes += content.bytesize
 
-    puts "#{lines} #{words} #{bytes} #{file}"
-    puts "#{total_lines} #{total_words} #{total_bytes} total"
-  end
+  puts "#{lines} #{words} #{bytes} #{file}"
+  puts "#{total_lines} #{total_words} #{total_bytes} total"
 end


### PR DESCRIPTION
以下の終了条件をすべてパスしています

- [x] `-lオプション`も実装すること。
- [x] 標準入力からも受け取れるようにして実行結果と出力を提出する。
- [x] 引数にファイル名が複数個来た場合にも対応し実行結果と出力を提出する。
- [x] 自作の`ls -l`コマンドと自作の`wc`コマンドをつなげた出力を提出する。
- [x] 本物の`ls -l`コマンド、本物の`wc`コマンドをつなげた出力を併記して提出すること。
- [x] rubocop-fjord のチェックが全てパスしたこともスクショで貼り付ける。

# スクリーンショット

自作wcコマンドの**引数なし, 引数なし-lオプション, 引数あり, 引数あり-lオプション**の出力結果

![自作wcコマンドの出力結果](https://user-images.githubusercontent.com/45246171/118771934-1923b680-b8be-11eb-895e-b667412aa99a.png)

自作の`ls -l` と`wcコマンド` と本物の`ls-l` と `wcコマンド` の結果を併記

![自作と本物の比較](https://user-images.githubusercontent.com/45246171/118772106-50926300-b8be-11eb-8b72-418de14d5556.png)
